### PR TITLE
add license to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='mgsub',
       author_email='b.mark@ewingsonline.com',
       url='https://github.com/bmewing/mgsub-python',
       packages=['mgsub'],
+      license='MIT',
       tests_require=['pytest'],
       keywords=['string', 'substitution', 'regex', 'regular expression'],
       classifiers=[


### PR DESCRIPTION
noticed was missing thanks to: [pypistats.org](https://pypistats.org/packages/mgsub) (relevant page linked)

